### PR TITLE
RDT 2.1: Account for corrupt ACK/NAKs

### DIFF
--- a/RDT 2.1/rdt_2_1.py
+++ b/RDT 2.1/rdt_2_1.py
@@ -100,23 +100,20 @@ class RDT:
         cur_seq = self.seq_num
         while(cur_seq >= self.seq_num):
             self.network.udt_send(p.get_byte_S())
-            #print("waiting...")
             recieved_byte_str = ''
             while(recieved_byte_str == ''):
                 recieved_byte_str = self.network.udt_receive()
-            #self.byte_buffer += recieved_byte_str
+                
             length = int(recieved_byte_str[:Packet.length_S_length])
-            #remove the packet bytes from the buffer
+            # remove the packet bytes from the buffer
             self.byte_buffer = recieved_byte_str[length:]
             pRec = Packet.from_byte_S(recieved_byte_str[:length])
 
-            # resend if a negative acknowledgement is recieved
-            if Packet.corrupt(pRec.msg_S) or Packet.isNAK(pRec.msg_S):
-                # print("NAK recieved. Resending...")
+            # resend if a corrupt pakcet or a negative acknowledgement is recieved
+            if Packet.corrupt(pRec.get_byte_S()) or Packet.isNAK(pRec.msg_S):
                 self.byte_buffer = ''
             # continue on if a positive acknowledgement is recieved
             elif Packet.isACK(pRec.msg_S):
-                #print("ACK recieved")
                 self.seq_num += 1
 
     # recieves a packet based on the RDT 2.1 protocol

--- a/RDT 2.1/rdt_2_1.py
+++ b/RDT 2.1/rdt_2_1.py
@@ -138,19 +138,20 @@ class RDT:
             length = int(self.byte_buffer[:Packet.length_S_length])
             if len(self.byte_buffer) < length:
                 return ret_S #not enough bytes to read the whole packet
-            #create packet from buffer content and add to return string
-            p = Packet.from_byte_S(self.byte_buffer[0:length])
 
-            # if a recieved packet has been corrupted, attempt to collect packets
-            if Packet.corrupt(p.get_byte_S()):
-                #print("Sending NAK")
+            # if a recieved packet has been corrupted, reset and re-request
+            if Packet.corrupt(self.byte_buffer[0:length]):
+                print("Sending NAK")
                 pak = Packet(self.seq_num, "NAK")
                 self.network.udt_send(pak.get_byte_S())
                 self.byte_buffer = ""
                 return None
-            else:
-                pak = Packet(self.seq_num, "ACK")
-                self.network.udt_send(pak.get_byte_S())
+
+            #create packet from buffer content and add to return string
+            p = Packet.from_byte_S(self.byte_buffer[0:length])
+
+            pak = Packet(self.seq_num, "ACK")
+            self.network.udt_send(pak.get_byte_S())
 
             ret_S = p.msg_S if (ret_S is None) else ret_S + p.msg_S
             #remove the packet bytes from the buffer

--- a/RDT 2.1/rdt_2_1.py
+++ b/RDT 2.1/rdt_2_1.py
@@ -57,7 +57,7 @@ class Packet:
 
 class RDT:
     ## latest sequence number used in a packet
-    seq_num = 1
+    seq_num = 0
     ## buffer of bytes read from network
     byte_buffer = ''
 
@@ -109,14 +109,15 @@ class RDT:
             #remove the packet bytes from the buffer
             self.byte_buffer = recieved_byte_str[length:]
             pRec = Packet.from_byte_S(recieved_byte_str[:length])
+
+            # resend if a negative acknowledgement is recieved
+            if Packet.corrupt(pRec.msg_S) or Packet.isNAK(pRec.msg_S):
+                # print("NAK recieved. Resending...")
+                self.byte_buffer = ''
             # continue on if a positive acknowledgement is recieved
-            if Packet.isACK(pRec.msg_S):
+            elif Packet.isACK(pRec.msg_S):
                 #print("ACK recieved")
                 self.seq_num += 1
-            # resend if a negative acknowledgement is recieved
-            elif Packet.isNAK(pRec.msg_S):
-                #print("NAK recieved. Resending...")
-                self.byte_buffer = ''
 
     # recieves a packet based on the RDT 2.1 protocol
     def rdt_2_1_receive(self):


### PR DESCRIPTION
RDT 2.0 has a fatal flaw. We haven't accounted for the corruptibility of the ACK/NAK.

Modify send and receive to account for this. Fully implement RDT 2.1